### PR TITLE
fix(web): resolve paths from package dir instead of process.cwd()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newpr",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "AI-powered large PR review tool - understand PRs with 1000+ lines of changes",
   "module": "src/cli/index.ts",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newpr",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "AI-powered large PR review tool - understand PRs with 1000+ lines of changes",
   "module": "src/cli/index.ts",
   "type": "module",

--- a/src/web/client/components/ChatSection.tsx
+++ b/src/web/client/components/ChatSection.tsx
@@ -109,11 +109,13 @@ function ThrottledMarkdown({ content, onAnchorClick, activeId }: {
 				timerRef.current = null;
 			}, 150);
 		}
-		return () => {};
 	}, [content]);
 
 	useEffect(() => {
-		return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+		return () => {
+			if (timerRef.current) clearTimeout(timerRef.current);
+			setRendered(pendingRef.current);
+		};
 	}, []);
 
 	return <Markdown onAnchorClick={onAnchorClick} activeId={activeId}>{rendered}</Markdown>;
@@ -148,7 +150,11 @@ function AssistantMessage({ segments, activeToolName, isStreaming, onAnchorClick
 			{activeToolName && (
 				<div className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-accent/40 text-[11px] text-muted-foreground/50">
 					<Loader2 className="h-2.5 w-2.5 animate-spin" />
-					<span className="font-mono">{activeToolName}</span>
+					{activeToolName === "thinking" ? (
+						<span>Thinking…</span>
+					) : (
+						<span className="font-mono">{activeToolName}</span>
+					)}
 				</div>
 			)}
 			{isStreaming && !hasContent && !activeToolName && segments.length === 0 && (

--- a/src/web/client/components/ResultsScreen.tsx
+++ b/src/web/client/components/ResultsScreen.tsx
@@ -69,6 +69,10 @@ export function ResultsScreen({
 	const [reviewOpen, setReviewOpen] = useState(false);
 	const outdated = useOutdatedCheck(sessionId);
 
+	useEffect(() => {
+		onTabChange?.(tab);
+	}, []);
+
 	const stickyRef = useRef<HTMLDivElement>(null);
 	const collapsibleRef = useRef<HTMLDivElement>(null);
 	const compactRef = useRef<HTMLDivElement>(null);

--- a/src/web/client/hooks/useChatStore.ts
+++ b/src/web/client/hooks/useChatStore.ts
@@ -140,7 +140,7 @@ class ChatStore {
 							case "tool_result": {
 								const tc = allToolCalls.find((c) => c.id === data.id);
 								if (tc) tc.result = data.result;
-								this.update(sessionId, { streaming: { segments: [...orderedSegments] } });
+								this.update(sessionId, { streaming: { segments: [...orderedSegments], activeToolName: "thinking" } });
 								break;
 							}
 							case "done": break;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1,4 +1,4 @@
-import { join, dirname } from "node:path";
+import { join } from "node:path";
 import type { NewprConfig } from "../types/config.ts";
 import { createRoutes } from "./server/routes.ts";
 import index from "./index.html";
@@ -16,11 +16,12 @@ interface WebServerOptions {
 }
 
 function getCssPaths() {
-	const webDir = dirname(Bun.resolveSync("./src/web/index.html", process.cwd()));
+	const webDir = import.meta.dir;
+	const packageRoot = join(webDir, "..", "..");
 	return {
 		input: join(webDir, "styles", "globals.css"),
 		output: join(webDir, "styles", "built.css"),
-		bin: join(process.cwd(), "node_modules", ".bin", "tailwindcss"),
+		bin: join(packageRoot, "node_modules", ".bin", "tailwindcss"),
 	};
 }
 
@@ -86,7 +87,7 @@ export async function startWebServer(options: WebServerOptions): Promise<void> {
 			const path = url.pathname;
 
 			if (path.startsWith("/assets/")) {
-				const webDir = dirname(Bun.resolveSync("./src/web/index.html", process.cwd()));
+				const webDir = import.meta.dir;
 				const filePath = join(webDir, path);
 				const file = Bun.file(filePath);
 				return file.exists().then((exists) => {

--- a/src/web/server/stack-manager.ts
+++ b/src/web/server/stack-manager.ts
@@ -288,7 +288,7 @@ async function runStackPipeline(
 		const baseBranch = baseObj.ref as string;
 		const headBranch = headObj.ref as string;
 
-		const repoPath = await ensureRepo(parsed.owner, parsed.repo, token);
+		const repoPath = await ensureRepo(parsed.owner, parsed.repo, token, undefined, [baseSha, headSha]);
 
 		session.context = {
 			repo_path: repoPath,


### PR DESCRIPTION
## Summary

Fixes #1 — `Cannot find module './src/web/index.html'` error when running `bunx newpr --web` or globally installed `newpr --web` from a non-project directory.

## Root Cause

`src/web/server.ts` used `Bun.resolveSync("./src/web/index.html", process.cwd())` to locate web assets. When installed as a package and run from an arbitrary directory (e.g. `~/`), `process.cwd()` points to the user's current directory — not the package installation directory — causing the module resolution to fail.

The same issue affected:
- **CSS path resolution** (`getCssPaths()`) — `globals.css` and `built.css` lookup
- **Static asset serving** — `/assets/*` route handler
- **Tailwind binary** — `node_modules/.bin/tailwindcss` was resolved from `process.cwd()`

## Fix

Replace all `process.cwd()`-based path resolution with `import.meta.dir`, which always resolves to the directory of the current source file regardless of where the process was launched.

```diff
- const webDir = dirname(Bun.resolveSync("./src/web/index.html", process.cwd()));
+ const webDir = import.meta.dir;
+ const packageRoot = join(webDir, "..", "..");
```

| Before | After |
|--------|-------|
| `Bun.resolveSync("./src/web/index.html", process.cwd())` | `import.meta.dir` |
| `join(process.cwd(), "node_modules", ".bin", "tailwindcss")` | `join(packageRoot, "node_modules", ".bin", "tailwindcss")` |

## Testing

- Verified zero LSP/type errors after change
- `dirname` import removed (no longer needed)