### PR TITLE
fix(config): allow running without OpenRouter API key

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -57,7 +57,7 @@ Options (review mode):
   -v, --version         Show version
 
 Environment Variables:
-  OPENROUTER_API_KEY    Required. Your OpenRouter API key.
+  OPENROUTER_API_KEY    Optional. Used when configured; otherwise local agent fallback is used.
   GITHUB_TOKEN          Optional. Falls back to gh CLI token.
   NEWPR_MODEL           Default model override.
   NEWPR_MAX_FILES       Max files to analyze (default: 100).

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -61,12 +61,7 @@ export async function loadConfig(
 ): Promise<NewprConfig> {
 	const stored = await (_readStore ?? readStoredConfig)();
 
-	const apiKey = process.env.OPENROUTER_API_KEY || stored.openrouter_api_key;
-	if (!apiKey) {
-		throw new Error(
-			"OPENROUTER_API_KEY is not set. Run `newpr auth` to configure, or set the environment variable.",
-		);
-	}
+	const apiKey = process.env.OPENROUTER_API_KEY || stored.openrouter_api_key || "";
 
 	const agentVal = stored.agent as NewprConfig["agent"];
 	const rawLang = process.env.NEWPR_LANGUAGE || stored.language || DEFAULT_CONFIG.language;


### PR DESCRIPTION
## Summary
- stop failing early in `loadConfig()` when `OPENROUTER_API_KEY` is missing so CLI/web can continue to agent fallback (Claude Code/local agent path)
- keep `openrouter_api_key` as an empty string when not configured, preserving existing downstream behavior (`createLlmClient` falls back when key is falsy)
- update CLI help text to reflect that `OPENROUTER_API_KEY` is optional

## Validation
- bun run typecheck

Closes #3